### PR TITLE
Clear debug flags only when reading new debug flags

### DIFF
--- a/src/Script.cs
+++ b/src/Script.cs
@@ -730,7 +730,6 @@ PhysicalGunObject/
 
             // reset status and debugging data every cycle
             debugText.Clear();
-            debugLogic.Clear();
             numberTransfers = numberRefineres = numberAssemblers = 0;
 
             try
@@ -858,6 +857,7 @@ PhysicalGunObject/
             argScanGrinders = DEFAULT_ARG_SCAN_GRINDERS;
             argScanWelders = DEFAULT_ARG_SCAN_WELDERS;
             argQuotaStable = DEFAULT_ARG_QUOTA_STABLE;
+            debugLogic.Clear();
 
             string arg, value;
             bool hasValue;


### PR DESCRIPTION
This causes TIM to retain debug flags from cycle to cycle, so that debug information remains visible as long as `debug=` options are present in the custom data of the block.

Before this change, debug flags were only in effect for the specific cycle where `ProcessScriptArgs` ran - the first cycle after any change to the block's custom data, and on script compilation, and on world load. After that, they reset to the default, and debug information would not display.

After this change, the debug state is "sticky," and only changes when the custom data changes or the script is reloaded. It no longer resets every tick, and debug information remains available from cycle to cycle.

This does _not_ preserve actual debug messages - only the set of flags indicating what debug messages to capture.